### PR TITLE
mgr/dashboard: Fix variable capitalization in embedded rbd-details panel

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
@@ -25,7 +25,7 @@ export class RbdDetailsComponent implements OnChanges {
 
   ngOnChanges() {
     if (this.selection) {
-      this.rbdDashboardUrl = `rbd-details?var-Pool=${this.selection['pool_name']}&var-Image=${this.selection['name']}`;
+      this.rbdDashboardUrl = `rbd-details?var-pool=${this.selection['pool_name']}&var-image=${this.selection['name']}`;
     }
   }
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/67849

The Performance tab of the dashboard is passing the `pool` and `image` variables to the Grafana iframe with the first letter in uppercase, but in the `monitoring/ceph-mixin/dashboards_out/rbd-details.json` dashboard file they are defined in lowercase, this causes them not to be recognized and the graphics display _No data_.

Example of current (wrong) generated URL:

`https://mycephdashboard.com/d/eRtdGrFfgT/rbd-details?var-Pool=pve_rbd_ssd&var-Image=base-501-disk-0 &refresh=5s&var-datasource=Dashboard1&kiosk&from=now-1h&to=now&orgId=1`

It should be:

`https://mycephdashboard.com/d/eRtdGrFfgT/rbd-details?var-pool=pve_rbd_ssd&var-image=base-501-disk-0 &refresh=5s&var-datasource=Dashboard1&kiosk&from=now-1h&to=now&orgId=1`

_Note that the `var-Image` and `var-Pool` URL variables have the first letter capitalized._

This is happening in all versions of ceph.

![image](https://github.com/user-attachments/assets/2c4d58be-03b7-483b-809f-59dc25cd2e86)

A workaround for this bug for a running production cluster could be rename the variables in the corresponding dashboard file.

```
sed -i \
    -e 's/\$image/\$Image/g' \
    -e 's/"name": "image"/"name": "Image"/g' \
    -e 's/\$pool/\$Pool/g' \
    -e 's/"name": "pool"/"name": "Pool"/g' \
    monitoring/ceph-mixin/dashboards_out/rbd-details.json
```